### PR TITLE
fix/backend-update-password-api

### DIFF
--- a/app/backend/src/main/java/com/arbitaja/backend/GlobalExceptionHandler.java
+++ b/app/backend/src/main/java/com/arbitaja/backend/GlobalExceptionHandler.java
@@ -75,6 +75,14 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.CONFLICT);
     }
 
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<Map<String, String>> handleUnauthorizedException(UnauthorizedException ex) {
+        Map<String, String> response = new HashMap<>();
+        response.put("error", "Unauthorized");
+        response.put("message", ex.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, String>> handleGeneralException(Exception ex) {
         Map<String, String> response = new HashMap<>();

--- a/app/backend/src/main/java/com/arbitaja/backend/users/APIs/UserController.java
+++ b/app/backend/src/main/java/com/arbitaja/backend/users/APIs/UserController.java
@@ -1,5 +1,6 @@
 package com.arbitaja.backend.users.APIs;
 import com.arbitaja.backend.GlobalExceptionHandler;
+import com.arbitaja.backend.users.APIs.requests.PasswordChangeRequest;
 import com.arbitaja.backend.users.APIs.responses.UserProfileResponse;
 import com.arbitaja.backend.users.dataobjects.SignupUser;
 import com.arbitaja.backend.users.dataobjects.User;
@@ -233,9 +234,9 @@ public class UserController {
     @Transactional
     @PutMapping("/profile/update_password")
     @PreAuthorize("hasAuthority('basic')")
-    public ResponseEntity<?> updatePassword(@RequestBody User user) throws JsonProcessingException {
+    public ResponseEntity<?> updatePassword(@RequestBody PasswordChangeRequest passwordChangeRequest) throws JsonProcessingException {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        ResponseEntity<?> resp = userService.changePassword(user, auth);
+        ResponseEntity<?> resp = userService.changePassword(passwordChangeRequest, auth);
         log.debug("Sending Response for successful password change: " + "{}", objectMapper.writeValueAsString(resp));
         return resp;
     }

--- a/app/backend/src/main/java/com/arbitaja/backend/users/APIs/requests/PasswordChangeRequest.java
+++ b/app/backend/src/main/java/com/arbitaja/backend/users/APIs/requests/PasswordChangeRequest.java
@@ -1,0 +1,41 @@
+package com.arbitaja.backend.users.APIs.requests;
+
+
+public class PasswordChangeRequest {
+    private Integer id;
+    private String old_password;
+    private String new_password;
+
+    public PasswordChangeRequest() {
+    }
+
+    public PasswordChangeRequest(Integer id, String old_password, String new_password) {
+        this.id = id;
+        this.old_password = old_password;
+        this.new_password = new_password;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getOld_password() {
+        return old_password;
+    }
+
+    public void setOld_password(String old_password) {
+        this.old_password = old_password;
+    }
+
+    public String getNew_password() {
+        return new_password;
+    }
+
+    public void setNew_password(String new_password) {
+        this.new_password = new_password;
+    }
+}


### PR DESCRIPTION
fix: When updating password for a regular user, old and new password is needed, but admin can change any password without old password