### PR TITLE
Feat/34 show detailed results

### DIFF
--- a/app/backend/src/main/java/com/arbitaja/backend/competitions/scorings/APIs/CompetitionScoringService.java
+++ b/app/backend/src/main/java/com/arbitaja/backend/competitions/scorings/APIs/CompetitionScoringService.java
@@ -241,10 +241,10 @@ public class CompetitionScoringService {
             List<CompetitionScoringResponse.Result> results = setResults(competition, competitor, score_showtime);
             // If the results are empty, set the score to 0.0
             if (results.isEmpty())
-                competitorSet.add(new CompetitionScoringResponse.Competitor(competitor.getAlias(), 0.0, results));
+                competitorSet.add(new CompetitionScoringResponse.Competitor(competitor.getId(), competitor.getAlias(), 0.0, results));
             // If the results are not empty, set the score to the last result
             else
-                competitorSet.add(new CompetitionScoringResponse.Competitor(competitor.getAlias(), results.getLast().getPoint_amount(), results));
+                competitorSet.add(new CompetitionScoringResponse.Competitor(competitor.getId(), competitor.getAlias(), results.getLast().getPoint_amount(), results));
         }
         return competitorSet;
     }

--- a/app/backend/src/main/java/com/arbitaja/backend/competitions/scorings/APIs/Response/CompetitionScoringResponse.java
+++ b/app/backend/src/main/java/com/arbitaja/backend/competitions/scorings/APIs/Response/CompetitionScoringResponse.java
@@ -25,14 +25,24 @@ public class CompetitionScoringResponse {
     }
 
     public static class Competitor {
+        private Integer id;
         private String name;
         private Double total_score;
         private List<Result> results;
 
-        public Competitor(String name, Double total_score, List<Result> results) {
+        public Competitor(Integer id, String name, Double total_score, List<Result> results) {
+            this.id = id;
             this.name = name;
             this.total_score = total_score;
             this.results = results;
+        }
+
+        public Integer getId() {
+            return id;
+        }
+
+        public void setId(Integer id) {
+            this.id = id;
         }
 
         public String getName() {

--- a/app/frontend/src/components/admin/competitions/addEditCompetition.vue
+++ b/app/frontend/src/components/admin/competitions/addEditCompetition.vue
@@ -268,6 +268,7 @@ const saveComp = async() => {
             <div class="col">
                 <label for="score_showtime" class="form-label"
                     title="
+                        INFO
                         Public accounts can only view score updates til this time. 
                         After that they turn stale and scores will stop updating for the public.
                         Scores will continue to update for admin users.
@@ -286,7 +287,30 @@ const saveComp = async() => {
                     id="score_showtime"
                 />
             </div>
-            
+        </div>
+        <div class="row justify-content-start pt-3">
+            <div class="col">
+                <label for="score_showtime" class="form-label"
+                    title="
+                        BEWARE!
+                        Publishing scores will make public all of the result after 'Public Score Update Time'. 
+                        Only IF YOU WANT TO MAKE THEM PUBLIC then publish results.
+                        You can always de-publish results, but someone might have already made a screenshot. 
+                    ">
+                    Publish Scores
+                    <i class="bi bi-info-circle"></i>
+                </label>
+                
+                
+            </div>
+            <div class="col">
+                <input
+                    type="checkbox"
+                    class="form-check-input"
+                    v-model="competition.publish_scores"
+                    id="publish_scores"
+                />
+            </div>
         </div>
 
         <!-- Organizer data start block -->

--- a/app/frontend/src/components/generic/competitions/competitionShow.vue
+++ b/app/frontend/src/components/generic/competitions/competitionShow.vue
@@ -7,7 +7,7 @@ import { DateTime } from 'luxon';
 import PulseLoader from 'vue-spinner/src/PulseLoader.vue';
 
 import competitionChartResults from './competitionChartResults.vue';
-import competitionResultTabel from './competitionResultTabel.vue';
+import competitionResultTabel from './competitionTabel/competitionResultTabel.vue';
 
 const route = useRoute();
 

--- a/app/frontend/src/components/generic/competitions/competitionTabel/competitionCollapse.vue
+++ b/app/frontend/src/components/generic/competitions/competitionTabel/competitionCollapse.vue
@@ -1,0 +1,120 @@
+<script setup>
+// Import stuff needed
+import { ref, defineProps } from 'vue';
+import axios from 'axios';
+import PulseLoader from 'vue-spinner/src/PulseLoader.vue';
+
+const isShow = ref(false);
+const isLoadingResults = ref(true);
+const results = ref([]);
+
+const props = defineProps({
+    competitionId: {
+        type: Number,
+        required: true,
+    },
+    competitor: {
+        type: Object,
+        required: true,
+    },
+    index: {
+        type: Number,
+        required: true,
+    },
+})
+
+const getCompetitorDetailedResults = async(competition_id, competitor_id) => {
+    try {
+        // Set Loading value to true
+        isLoadingResults.value = true
+
+        // Get the results
+        const response = await axios.get(
+            'dashboard/competition/criteria/competitor', 
+            { 
+                params: {
+                    competition_id: ''+competition_id,
+                    competitor_id: ''+competitor_id
+                }
+            }
+        )
+
+        // Set results
+        results.value = response.data.criterias
+        console.log(results.value)
+
+    } catch (error) {
+        showAlert('Couldn\'t get competitors for the user tabel. Error:' + error, 'warning')
+    } finally {
+        isLoadingResults.value = false
+    }
+}
+
+
+// Alert function
+const alertTimeout = ref(3000)
+const alertMessage = ref('')
+const alertType = ref('')
+
+import displayAlert from '@/components/generic/displayAlert.vue';
+
+function showAlert(message, type, timeout){
+    alertMessage.value = message
+    alertType.value = type
+    alertTimeout.value = timeout
+}
+
+const openCollapse = (competitor) => {
+    isShow.value = !isShow.value
+    getCompetitorDetailedResults(props.competitionId, competitor.id)
+}
+
+</script>
+
+<template>
+    <th scope="row">
+        {{ index + 1 }}
+    </th>
+    <td>
+        {{ competitor.name }}
+        <div v-if="isShow" class="row">
+            <div v-if="isLoadingResults">
+                <PulseLoader />
+            </div>
+                <table v-else class="table table-striped mt-3">
+                    <thead>
+                    <th scope="col">Criteria Name</th>
+                </thead>
+                <tbody>
+                    <tr v-for="result in results">
+                        <td>{{ result.name }}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </td>
+    <td>
+        {{ competitor.total_score }}
+        <div v-if="isShow" class="row">
+            <div v-if="isLoadingResults">
+                <PulseLoader />
+            </div>
+                <table v-else class="table table-striped mt-3">
+                    <thead>
+                    <th scope="col">Points</th>
+                </thead>
+                <tbody>
+                    <tr v-for="result in results">
+                        <td>{{ result.points }}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </td>
+    <td>
+        <button v-if="isShow" class="btn bi bi-caret-up-fill" @click="isShow = !isShow"></button>
+        <button v-if="!isShow" class="btn bi bi-caret-down-fill" @click="openCollapse(competitor)"></button>
+    </td>
+    <!-- Alert when needed -->
+    <displayAlert :message="alertMessage" :type="alertType" :timeout="alertTimeout" />
+</template>

--- a/app/frontend/src/components/generic/competitions/competitionTabel/competitionCollapse.vue
+++ b/app/frontend/src/components/generic/competitions/competitionTabel/competitionCollapse.vue
@@ -4,6 +4,9 @@ import { ref, defineProps } from 'vue';
 import axios from 'axios';
 import PulseLoader from 'vue-spinner/src/PulseLoader.vue';
 
+// Emit an error to parent alert
+const emit = defineEmits(['showAlert'])
+
 const isShow = ref(false);
 const isLoadingResults = ref(true);
 const results = ref([]);
@@ -23,7 +26,7 @@ const props = defineProps({
     },
 })
 
-const getCompetitorDetailedResults = async(competition_id, competitor_id) => {
+const getCompetitorDetailedResults = async(competition_id, competitor) => {
     try {
         // Set Loading value to true
         isLoadingResults.value = true
@@ -34,7 +37,7 @@ const getCompetitorDetailedResults = async(competition_id, competitor_id) => {
             { 
                 params: {
                     competition_id: ''+competition_id,
-                    competitor_id: ''+competitor_id
+                    competitor_id: ''+competitor.id
                 }
             }
         )
@@ -44,7 +47,7 @@ const getCompetitorDetailedResults = async(competition_id, competitor_id) => {
         console.log(results.value)
 
     } catch (error) {
-        showAlert('Couldn\'t get competitors for the user tabel. Error:' + error, 'warning')
+        showAlert('Couldn\'t get criteria restults for the competitor: "'+ competitor.name +'". Error:' + error, 'warning')
     } finally {
         isLoadingResults.value = false
     }
@@ -52,21 +55,13 @@ const getCompetitorDetailedResults = async(competition_id, competitor_id) => {
 
 
 // Alert function
-const alertTimeout = ref(3000)
-const alertMessage = ref('')
-const alertType = ref('')
-
-import displayAlert from '@/components/generic/displayAlert.vue';
-
 function showAlert(message, type, timeout){
-    alertMessage.value = message
-    alertType.value = type
-    alertTimeout.value = timeout
+    emit('showAlert', message, type, timeout)
 }
 
 const openCollapse = (competitor) => {
     isShow.value = !isShow.value
-    getCompetitorDetailedResults(props.competitionId, competitor.id)
+    getCompetitorDetailedResults(props.competitionId, competitor)
 }
 
 </script>
@@ -115,6 +110,5 @@ const openCollapse = (competitor) => {
         <button v-if="isShow" class="btn bi bi-caret-up-fill" @click="isShow = !isShow"></button>
         <button v-if="!isShow" class="btn bi bi-caret-down-fill" @click="openCollapse(competitor)"></button>
     </td>
-    <!-- Alert when needed -->
-    <displayAlert :message="alertMessage" :type="alertType" :timeout="alertTimeout" />
+    
 </template>

--- a/app/frontend/src/components/generic/competitions/competitionTabel/competitionResultTabel.vue
+++ b/app/frontend/src/components/generic/competitions/competitionTabel/competitionResultTabel.vue
@@ -130,6 +130,8 @@ function showAlert(message, type, timeout){
     alertTimeout.value = timeout
 }
 
+import competitionCollapse from './competitionCollapse.vue';
+
 </script>
 
 <template>
@@ -145,12 +147,11 @@ function showAlert(message, type, timeout){
             <th scope="col">#</th>
             <th scope="col">Name</th>
             <th scope="col">Total Points</th>
+            <th scope="col">Show Details</th>
         </thead>
         <tbody>
             <tr v-for="(competitor, index) in sortedComptitors">
-                <th scope="row">{{ index + 1 }}</th>
-                <td>{{ competitor.name }}</td>
-                <td>{{ competitor.total_score }}</td>
+                <competitionCollapse :competitionId="competitionId" :competitor="competitor" :index="index"/>
             </tr>
         </tbody>
     </table>

--- a/app/frontend/src/components/generic/competitions/competitionTabel/competitionResultTabel.vue
+++ b/app/frontend/src/components/generic/competitions/competitionTabel/competitionResultTabel.vue
@@ -151,7 +151,7 @@ import competitionCollapse from './competitionCollapse.vue';
         </thead>
         <tbody>
             <tr v-for="(competitor, index) in sortedComptitors">
-                <competitionCollapse :competitionId="competitionId" :competitor="competitor" :index="index"/>
+                <competitionCollapse :competitionId="competitionId" :competitor="competitor" :index="index" @showAlert="showAlert"/>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
Add detailed viewing results for users that looks something like this:
<img width="1380" height="778" alt="image" src="https://github.com/user-attachments/assets/b57d6a6b-2fc9-4dd0-9ff3-1850dbb26d2e" />
Connected with the issue: #34 

Also added possibility to publish results of a competition:
Connected with the issue: #30 
